### PR TITLE
fix: Add `field_behavior = REQUIRED` for all path parameters

### DIFF
--- a/google/api/field_behavior.proto
+++ b/google/api/field_behavior.proto
@@ -1,0 +1,78 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "FieldBehaviorProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.FieldOptions {
+  // A designation of a specific field behavior (required, output only, etc.)
+  // in protobuf messages.
+  //
+  // Examples:
+  //
+  //   string name = 1 [(google.api.field_behavior) = REQUIRED];
+  //   State state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  //   google.protobuf.Duration ttl = 1
+  //     [(google.api.field_behavior) = INPUT_ONLY];
+  //   google.protobuf.Timestamp expire_time = 1
+  //     [(google.api.field_behavior) = OUTPUT_ONLY,
+  //      (google.api.field_behavior) = IMMUTABLE];
+  repeated google.api.FieldBehavior field_behavior = 1052;
+}
+
+// An indicator of the behavior of a given field (for example, that a field
+// is required in requests, or given as output but ignored as input).
+// This **does not** change the behavior in protocol buffers itself; it only
+// denotes the behavior and may affect how API tooling handles the field.
+//
+// Note: This enum **may** receive new values in the future.
+enum FieldBehavior {
+  // Conventional default for enums. Do not use this.
+  FIELD_BEHAVIOR_UNSPECIFIED = 0;
+
+  // Specifically denotes a field as optional.
+  // While all fields in protocol buffers are optional, this may be specified
+  // for emphasis if appropriate.
+  OPTIONAL = 1;
+
+  // Denotes a field as required.
+  // This indicates that the field **must** be provided as part of the request,
+  // and failure to do so will cause an error (usually `INVALID_ARGUMENT`).
+  REQUIRED = 2;
+
+  // Denotes a field as output only.
+  // This indicates that the field is provided in responses, but including the
+  // field in a request does nothing (the server *must* ignore it and
+  // *must not* throw an error as a result of the field's presence).
+  OUTPUT_ONLY = 3;
+
+  // Denotes a field as input only.
+  // This indicates that the field is provided in requests, and the
+  // corresponding field is not included in output.
+  INPUT_ONLY = 4;
+
+  // Denotes a field as immutable.
+  // This indicates that the field may be set once in a request to create a
+  // resource, but may not be changed thereafter.
+  IMMUTABLE = 5;
+}

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
@@ -261,6 +261,9 @@ public class DocumentToProtoConverter {
         String httpOptionPath = method.flatPath();
         for (Schema pathParam : method.pathParams().values()) {
           Field pathField = schemaToField(pathParam);
+          Option fieldBehaviorOption = new Option("google.api.field_behavior");
+          fieldBehaviorOption.getProperties().put("", "REQUIRED");
+          pathField.getOptions().add(fieldBehaviorOption);
           input.getFields().add(pathField);
           httpOptionPath =
               httpOptionPath.replace(

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Option.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Option.java
@@ -44,8 +44,7 @@ public class Option {
       return false;
     }
     Option option = (Option) o;
-    return Objects.equals(name, option.name) &&
-        Objects.equals(properties, option.properties);
+    return Objects.equals(name, option.name) && Objects.equals(properties, option.properties);
   }
 
   @Override

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -4,6 +4,7 @@ package google.cloud.compute.v1;
 
 import "google/api/annotations.proto";
 import "google/api/client.proto";
+import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 
 option csharp_namespace = "Google.Cloud.Compute.V1";
@@ -193,15 +194,15 @@ message AddressList {
 }
 
 message InsertAddressRequest {
-  string project = 1;
-  string region = 2;
+  string project = 1 [(google.api.field_behavior) = REQUIRED];
+  string region = 2 [(google.api.field_behavior) = REQUIRED];
   string request_id = 3;
   Address address_resource = 4;
 }
 
 message ListAddressesRequest {
-  string project = 1;
-  string region = 2;
+  string project = 1 [(google.api.field_behavior) = REQUIRED];
+  string region = 2 [(google.api.field_behavior) = REQUIRED];
   string filter = 3;
   uint32 max_results = 4;
   string order_by = 5;


### PR DESCRIPTION
Path parameters always must be set, otherwise there is no way to make a valid http request. This also helps with tests and embedded samples generation in gapic-genrator automatically (it pupulates the fields marked as required, which is crucial to make unit tests tests pass).

(this PR also includes some simple code reformatting)