### PR TITLE
feat: Implement hash-based proto message field numbers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>26.0-jre</version>
+      <version>28.2-android</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
@@ -131,6 +131,11 @@ public class Name {
     this.namePieces = namePieces;
   }
 
+  /** Returns the identifier in upper-underscore format. */
+  public String toUpperUnderscore() {
+    return toUnderscore(CaseFormat.UPPER_UNDERSCORE);
+  }
+
   /** Returns the identifier in lower-underscore format. */
   public String toLowerUnderscore() {
     return toUnderscore(CaseFormat.LOWER_UNDERSCORE);

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
@@ -237,7 +237,7 @@ public class DocumentToProtoConverter {
       String name, String description, List<String> enumVals, List<String> enumDescs) {
     Message enumMessage = new Message(name, false, true, description);
 
-    String dummyDesc = "A dummy enum value indicating that the enum field is not set.";
+    String dummyDesc = "A value indicating that the enum field is not set.";
     String dummyFieldName = Name.anyCamel("Undefined", name).toUpperUnderscore();
 
     Field dummyField =

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Field.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Field.java
@@ -16,28 +16,10 @@
 package com.google.cloud.discotoproto3converter.proto3;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 public class Field extends ProtoElement {
-  public static final Map<String, Message> PRIMITIVES = new HashMap<>();
-
-  static {
-    PRIMITIVES.put("bool", new Message("bool", false, false, null));
-    PRIMITIVES.put("string", new Message("string", false, false, null));
-    PRIMITIVES.put("int32", new Message("int32", false, false, null));
-    PRIMITIVES.put("fixed32", new Message("fixed32", false, false, null));
-    PRIMITIVES.put("uint32", new Message("uint32", false, false, null));
-    PRIMITIVES.put("int64", new Message("int64", false, false, null));
-    PRIMITIVES.put("fixed64", new Message("fixed64", false, false, null));
-    PRIMITIVES.put("unit64", new Message("unit64", false, false, null));
-    PRIMITIVES.put("float", new Message("float", false, false, null));
-    PRIMITIVES.put("double", new Message("double", false, false, null));
-    PRIMITIVES.put("", new Message("", false, true, null));
-  }
-
   private final String name;
   private Message valueType;
   private final boolean repeated;

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
@@ -68,11 +68,13 @@ public class Message extends ProtoElement {
             .sorted(Comparator.comparing(Field::getName))
             .collect(Collectors.toList());
     if (isEnum) {
+      // Make sure that the first element of an enum is always the dummy value
       sortedFields.add(0, fields.get(0));
     }
 
     for (Field f : sortedFields) {
       if (fieldsWithNumbers.isEmpty() && isEnum()) {
+        // For enum, the first element should always have number 0.
         fieldsWithNumbers.put(0, f);
         continue;
       }
@@ -86,6 +88,8 @@ public class Message extends ProtoElement {
     return fieldsWithNumbers;
   }
 
+  // All the "magic numbers" come from the proto3 spec:
+  // https://developers.google.com/protocol-buffers/docs/proto3#assigning_field_numbers
   private int getFieldNumber(String fieldName) {
     int fieldNumber = (fieldName.hashCode() << 3) >>> 3;
     if (fieldNumber == 0 || (fieldNumber >= 19000 && fieldNumber <= 19999)) {
@@ -96,7 +100,7 @@ public class Message extends ProtoElement {
 
   private int incrementFieldNumber(int fieldNumber) {
     int incrementedFieldNumber = fieldNumber + 1;
-    if ((fieldNumber >= 19000 && fieldNumber <= 19999)) {
+    if ((fieldNumber >= 19000 && fieldNumber <= 19999) || fieldNumber >= (1 << 29)) {
       incrementedFieldNumber = 20000;
     }
     return incrementedFieldNumber;

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
@@ -87,7 +87,7 @@ public class Message extends ProtoElement {
   }
 
   private int getFieldNumber(String fieldName) {
-    int fieldNumber = fieldName.hashCode() >>> 3;
+    int fieldNumber = (fieldName.hashCode() << 3) >>> 3;
     if (fieldNumber == 0 || (fieldNumber >= 19000 && fieldNumber <= 19999)) {
       fieldNumber = 20000 + ((fieldNumber % 19000) + 1) * 536314;
     }

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Proto3Writer.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Proto3Writer.java
@@ -142,12 +142,13 @@ public class Proto3Writer {
 
       printMessages(message.getEnums(), writer, indent + "  ");
 
-      int fieldIndex = message.isEnum() ? 0 : 1;
-      for (Field field : message.getFields()) {
+      for (Map.Entry<Integer, Field> entry : message.getFieldsWithNumbers().entrySet()) {
+        Field field = entry.getValue();
+        int fieldIndex = entry.getKey();
         if (field.getDescription() != null && !field.getDescription().isEmpty()) {
           writer.println(formatDescription(indent + "  ", field.getDescription()));
         }
-        writer.print(indent + "  " + field.toString(fieldIndex++));
+        writer.print(indent + "  " + field.toString(fieldIndex));
 
         String options = ";";
         if (!field.getOptions().isEmpty()) {

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -44,11 +44,11 @@ message Address {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_ADDRESS_TYPE = 0;
 
-    EXTERNAL = 407104121;
+    EXTERNAL = 35607499;
 
-    INTERNAL = 169129687;
+    INTERNAL = 279295677;
 
-    UNSPECIFIED_TYPE = 342286060;
+    UNSPECIFIED_TYPE = 53933922;
 
   }
 
@@ -57,11 +57,11 @@ message Address {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_IP_VERSION = 0;
 
-    IPV4 = 281792;
+    IPV4 = 2254341;
 
-    IPV6 = 281793;
+    IPV6 = 2254343;
 
-    UNSPECIFIED_VERSION = 405384434;
+    UNSPECIFIED_VERSION = 21850000;
 
   }
 
@@ -72,9 +72,9 @@ message Address {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 49941318;
+    PREMIUM = 399530551;
 
-    STANDARD = 261906903;
+    STANDARD = 484642493;
 
   }
 
@@ -87,13 +87,13 @@ message Address {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_PURPOSE = 0;
 
-    DNS_RESOLVER = 395058639;
+    DNS_RESOLVER = 476114556;
 
-    GCE_ENDPOINT = 297249861;
+    GCE_ENDPOINT = 230515243;
 
-    NAT_AUTO = 356002629;
+    NAT_AUTO = 163666477;
 
-    VPC_PEERING = 385644341;
+    VPC_PEERING = 400800170;
 
   }
 
@@ -102,100 +102,100 @@ message Address {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    IN_USE = 270609641;
+    IN_USE = 17393485;
 
-    RESERVED = 54030181;
+    RESERVED = 432241448;
 
-    RESERVING = 64323403;
+    RESERVING = 514587225;
 
   }
 
   // The static IP address represented by this resource.
-  string address = 393409406;
+  string address = 462920692;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
-  AddressType address_type = 33038484;
+  AddressType address_type = 264307877;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
-  string creation_timestamp = 70924534;
+  string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  string description = 321302655;
+  string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
-  string id = 419;
+  string id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  IpVersion ip_version = 372414264;
+  IpVersion ip_version = 294959552;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
-  string kind = 411506;
+  string kind = 3292052;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?`. The first character must be a lowercase letter, and all following characters (except for the last character) must be a dash, lowercase letter, or digit. The last character must be a lowercase letter or digit.
-  string name = 421713;
+  string name = 3373707;
 
   // The URL of the network in which to reserve the address. This field can only be used with INTERNAL type with the VPC_PEERING purpose.
-  string network = 230435653;
+  string network = 232872494;
 
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  NetworkTier network_tier = 534436778;
+  NetworkTier network_tier = 517397843;
 
   // The prefix length if the resource reprensents an IP range.
-  int32 prefix_length = 392240038;
+  int32 prefix_length = 453565747;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
   // - `DNS_RESOLVER` for a DNS resolver address in a subnetwork
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
-  Purpose purpose = 509312931;
+  Purpose purpose = 316407070;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
-  string region = 420021470;
+  string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  string self_link = 325462305;
+  string self_link = 456214797;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
-  Status status = 425310718;
+  Status status = 181260274;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  string subnetwork = 374022781;
+  string subnetwork = 307827694;
 
   // [Output Only] The URLs of the resources that are using this address.
-  repeated string users = 13947329;
+  repeated string users = 111578632;
 
 }
 
 //
 message Errors {
   // [Output Only] The error type identifier for this error.
-  string code = 382397;
+  string code = 3059181;
 
   // [Output Only] Indicates the field in the request that caused the error. This property is optional.
-  string location = 237630454;
+  string location = 290430901;
 
   // [Output Only] An optional, human-readable error message.
-  string message = 119365632;
+  string message = 418054151;
 
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
 message Error {
   // [Output Only] The array of errors encountered while processing this operation.
-  repeated Errors errors = 375041517;
+  repeated Errors errors = 315977579;
 
 }
 
 //
 message Data {
   // [Output Only] A key that provides more detail on the warning being returned. For example, for warnings where there are no results in a list request for a particular zone, this key might be scope and the key value might be the zone name. Other examples might be a key indicating a deprecated resource and a suggested replacement, or a warning about invalid network settings (for example, if an instance attempts to perform IP forwarding but is not enabled for IP forwarding).
-  string key = 13259;
+  string key = 106079;
 
   // [Output Only] A warning data value corresponding to the key.
-  string value = 13996590;
+  string value = 111972721;
 
 }
 
@@ -206,63 +206,63 @@ message Warnings {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_CODE = 0;
 
-    CLEANUP_FAILED = 18788555;
+    CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 48979448;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 110424642;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 381724690;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 56494305;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
-    EXTERNAL_API_WARNING = 223269880;
+    EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 309644133;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 521934225;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    MISSING_TYPE_DEPENDENCY = 244389774;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 40620624;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 450576044;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 192249033;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
-    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 164687496;
+    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 320570614;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
-    NOT_CRITICAL_ERROR = 482982538;
+    NOT_CRITICAL_ERROR = 105763924;
 
-    NO_RESULTS_ON_PAGE = 473516641;
+    NO_RESULTS_ON_PAGE = 30036744;
 
-    REQUIRED_TOS_AGREEMENT = 470230240;
+    REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 397635400;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
-    RESOURCE_NOT_DELETED = 356619127;
+    RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 101514569;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
-    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 369082522;
+    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 48814179;
+    UNDECLARED_PROPERTIES = 390513439;
 
-    UNREACHABLE = 135883734;
+    UNREACHABLE = 13328052;
 
   }
 
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
-  Code code = 382397;
+  Code code = 3059181;
 
   // [Output Only] Metadata about this warning in key: value format. For example:
   // "data": [ { "key": "scope", "value": "zones/us-east1-d" }
-  repeated Data data = 384501;
+  repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  string message = 119365632;
+  string message = 418054151;
 
 }
 
@@ -286,82 +286,82 @@ message Operation {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    DONE = 263024;
+    DONE = 2104194;
 
-    PENDING = 4424366;
+    PENDING = 35394935;
 
-    RUNNING = 283595827;
+    RUNNING = 121282975;
 
   }
 
   // [Output Only] The value of `requestId` if you provided it in the request. Not present otherwise.
-  string client_operation_id = 506917084;
+  string client_operation_id = 297240295;
 
   // [Deprecated] This field is deprecated.
-  string creation_timestamp = 70924534;
+  string creation_timestamp = 30525366;
 
   // [Output Only] A textual description of the operation, which is set when the operation is created.
-  string description = 321302655;
+  string description = 422937596;
 
   // [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-  string end_time = 215693942;
+  string end_time = 114938801;
 
   // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-  Error error = 12098113;
+  Error error = 96784904;
 
   // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as NOT FOUND.
-  string http_error_message = 159532971;
+  string http_error_message = 202521945;
 
   // [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a 404 means the resource was not found.
-  int32 http_error_status_code = 173260877;
+  int32 http_error_status_code = 312345196;
 
   // [Output Only] The unique identifier for the operation. This identifier is defined by the server.
-  string id = 419;
+  string id = 3355;
 
   // [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
-  string insert_time = 523977362;
+  string insert_time = 433722515;
 
   // [Output Only] Type of the resource. Always compute#operation for Operation resources.
-  string kind = 411506;
+  string kind = 3292052;
 
   // [Output Only] Name of the operation.
-  string name = 421713;
+  string name = 3373707;
 
   // [Output Only] The type of operation, such as insert, update, or delete, and so on.
-  string operation_type = 357750626;
+  string operation_type = 177650450;
 
   // [Output Only] An optional progress indicator that ranges from 0 to 100. There is no requirement that this be linear or support any granularity of operations. This should not be used to guess when the operation will be complete. This number should monotonically increase as the operation progresses.
-  int32 progress = 411736133;
+  int32 progress = 72663597;
 
   // [Output Only] The URL of the region where the operation resides. Only applicable when performing regional operations.
-  string region = 420021470;
+  string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  string self_link = 325462305;
+  string self_link = 456214797;
 
   // [Output Only] The time that this operation was started by the server. This value is in RFC3339 text format.
-  string start_time = 340227729;
+  string start_time = 37467274;
 
   // [Output Only] The status of the operation, which can be one of the following: PENDING, RUNNING, or DONE.
-  Status status = 425310718;
+  Status status = 181260274;
 
   // [Output Only] An optional textual description of the current status of the operation.
-  string status_message = 506940567;
+  string status_message = 297428154;
 
   // [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
-  string target_id = 434923857;
+  string target_id = 258165385;
 
   // [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
-  string target_link = 276269373;
+  string target_link = 62671336;
 
   // [Output Only] User who requested the operation, for example: user@example.com.
-  string user = 449913;
+  string user = 3599307;
 
   // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-  repeated Warnings warnings = 62261386;
+  repeated Warnings warnings = 498091095;
 
   // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
-  string zone = 468085;
+  string zone = 3744684;
 
 }
 
@@ -372,104 +372,104 @@ message Warning {
     // A dummy enum value indicating that the enum field is not set.
     UNDEFINED_CODE = 0;
 
-    CLEANUP_FAILED = 18788555;
+    CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 48979448;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 110424642;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 381724690;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 56494305;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
-    EXTERNAL_API_WARNING = 223269880;
+    EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 309644133;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 521934225;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    MISSING_TYPE_DEPENDENCY = 244389774;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 40620624;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 450576044;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 192249033;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
-    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 164687496;
+    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 320570614;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
-    NOT_CRITICAL_ERROR = 482982538;
+    NOT_CRITICAL_ERROR = 105763924;
 
-    NO_RESULTS_ON_PAGE = 473516641;
+    NO_RESULTS_ON_PAGE = 30036744;
 
-    REQUIRED_TOS_AGREEMENT = 470230240;
+    REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 397635400;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
-    RESOURCE_NOT_DELETED = 356619127;
+    RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 101514569;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
-    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 369082522;
+    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 48814179;
+    UNDECLARED_PROPERTIES = 390513439;
 
-    UNREACHABLE = 135883734;
+    UNREACHABLE = 13328052;
 
   }
 
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
-  Code code = 382397;
+  Code code = 3059181;
 
   // [Output Only] Metadata about this warning in key: value format. For example:
   // "data": [ { "key": "scope", "value": "zones/us-east1-d" }
-  repeated Data data = 384501;
+  repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  string message = 119365632;
+  string message = 418054151;
 
 }
 
 // Contains a list of addresses.
 message AddressList {
   // [Output Only] Unique identifier for the resource; defined by the server.
-  string id = 419;
+  string id = 3355;
 
   // A list of Address resources.
-  repeated Address items = 12565752;
+  repeated Address items = 100526016;
 
   // [Output Only] Type of resource. Always compute#addressList for lists of addresses.
-  string kind = 411506;
+  string kind = 3292052;
 
   // [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
-  string next_page_token = 345519010;
+  string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  string self_link = 325462305;
+  string self_link = 456214797;
 
   // [Output Only] Informational warning message.
-  Warning warning = 140555763;
+  Warning warning = 50704284;
 
 }
 
 // A request message for Addresses.Insert. See the method description for details.
 message InsertAddressRequest {
-  Address address_resource = 328921471;
+  Address address_resource = 483888121;
 
   // Project ID for this request.
-  string project = 498207075 [(google.api.field_behavior) = REQUIRED];
+  string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the region for this request.
-  string region = 420021470 [(google.api.field_behavior) = REQUIRED];
+  string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
   // For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments.
   //
   // The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-  string request_id = 4638745;
+  string request_id = 37109963;
 
 }
 
@@ -482,26 +482,26 @@ message ListAddressesRequest {
   // You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
-  string filter = 377559407;
+  string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
-  uint32 max_results = 141057155;
+  uint32 max_results = 54715419;
 
   // Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.
   //
   // You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.
   //
   // Currently, only sorting by name or creationTimestamp desc is supported.
-  string order_by = 154288093;
+  string order_by = 160562920;
 
   // Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
-  string page_token = 203825929;
+  string page_token = 19994697;
 
   // Project ID for this request.
-  string project = 498207075 [(google.api.field_behavior) = REQUIRED];
+  string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the region for this request.
-  string region = 420021470 [(google.api.field_behavior) = REQUIRED];
+  string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
 }
 

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -41,21 +41,27 @@ option ruby_package = "Google::Cloud::Compute::V1";
 message Address {
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
   enum AddressType {
-    EXTERNAL = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_ADDRESS_TYPE = 0;
 
-    INTERNAL = 1;
+    EXTERNAL = 407104121;
 
-    UNSPECIFIED_TYPE = 2;
+    INTERNAL = 169129687;
+
+    UNSPECIFIED_TYPE = 342286060;
 
   }
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
   enum IpVersion {
-    IPV4 = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_IP_VERSION = 0;
 
-    IPV6 = 1;
+    IPV4 = 281792;
 
-    UNSPECIFIED_VERSION = 2;
+    IPV6 = 281793;
+
+    UNSPECIFIED_VERSION = 405384434;
 
   }
 
@@ -63,9 +69,12 @@ message Address {
   //
   // If this field is not specified, it is assumed to be PREMIUM.
   enum NetworkTier {
-    PREMIUM = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_NETWORK_TIER = 0;
 
-    STANDARD = 1;
+    PREMIUM = 49941318;
+
+    STANDARD = 261906903;
 
   }
 
@@ -75,112 +84,118 @@ message Address {
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
   enum Purpose {
-    DNS_RESOLVER = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_PURPOSE = 0;
 
-    GCE_ENDPOINT = 1;
+    DNS_RESOLVER = 395058639;
 
-    NAT_AUTO = 2;
+    GCE_ENDPOINT = 297249861;
 
-    VPC_PEERING = 3;
+    NAT_AUTO = 356002629;
+
+    VPC_PEERING = 385644341;
 
   }
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
   enum Status {
-    IN_USE = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_STATUS = 0;
 
-    RESERVED = 1;
+    IN_USE = 270609641;
 
-    RESERVING = 2;
+    RESERVED = 54030181;
+
+    RESERVING = 64323403;
 
   }
 
   // The static IP address represented by this resource.
-  string address = 1;
+  string address = 393409406;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
-  AddressType address_type = 2;
+  AddressType address_type = 33038484;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
-  string creation_timestamp = 3;
+  string creation_timestamp = 70924534;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  string description = 4;
+  string description = 321302655;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
-  string id = 5;
+  string id = 419;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  IpVersion ip_version = 6;
+  IpVersion ip_version = 372414264;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
-  string kind = 7;
+  string kind = 411506;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?`. The first character must be a lowercase letter, and all following characters (except for the last character) must be a dash, lowercase letter, or digit. The last character must be a lowercase letter or digit.
-  string name = 8;
+  string name = 421713;
 
   // The URL of the network in which to reserve the address. This field can only be used with INTERNAL type with the VPC_PEERING purpose.
-  string network = 9;
+  string network = 230435653;
 
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  NetworkTier network_tier = 10;
+  NetworkTier network_tier = 534436778;
 
   // The prefix length if the resource reprensents an IP range.
-  int32 prefix_length = 11;
+  int32 prefix_length = 392240038;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
   // - `DNS_RESOLVER` for a DNS resolver address in a subnetwork
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
-  Purpose purpose = 12;
+  Purpose purpose = 509312931;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
-  string region = 13;
+  string region = 420021470;
 
   // [Output Only] Server-defined URL for the resource.
-  string self_link = 14;
+  string self_link = 325462305;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
-  Status status = 15;
+  Status status = 425310718;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  string subnetwork = 16;
+  string subnetwork = 374022781;
 
   // [Output Only] The URLs of the resources that are using this address.
-  repeated string users = 17;
+  repeated string users = 13947329;
 
 }
 
 //
 message Errors {
   // [Output Only] The error type identifier for this error.
-  string code = 1;
+  string code = 382397;
 
   // [Output Only] Indicates the field in the request that caused the error. This property is optional.
-  string location = 2;
+  string location = 237630454;
 
   // [Output Only] An optional, human-readable error message.
-  string message = 3;
+  string message = 119365632;
 
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
 message Error {
   // [Output Only] The array of errors encountered while processing this operation.
-  repeated Errors errors = 1;
+  repeated Errors errors = 375041517;
 
 }
 
 //
 message Data {
   // [Output Only] A key that provides more detail on the warning being returned. For example, for warnings where there are no results in a list request for a particular zone, this key might be scope and the key value might be the zone name. Other examples might be a key indicating a deprecated resource and a suggested replacement, or a warning about invalid network settings (for example, if an instance attempts to perform IP forwarding but is not enabled for IP forwarding).
-  string key = 1;
+  string key = 13259;
 
   // [Output Only] A warning data value corresponding to the key.
-  string value = 2;
+  string value = 13996590;
 
 }
 
@@ -188,63 +203,66 @@ message Data {
 message Warnings {
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
   enum Code {
-    CLEANUP_FAILED = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_CODE = 0;
 
-    DEPRECATED_RESOURCE_USED = 1;
+    CLEANUP_FAILED = 18788555;
 
-    DEPRECATED_TYPE_USED = 2;
+    DEPRECATED_RESOURCE_USED = 48979448;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 3;
+    DEPRECATED_TYPE_USED = 110424642;
 
-    EXPERIMENTAL_TYPE_USED = 4;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 381724690;
 
-    EXTERNAL_API_WARNING = 5;
+    EXPERIMENTAL_TYPE_USED = 56494305;
 
-    FIELD_VALUE_OVERRIDEN = 6;
+    EXTERNAL_API_WARNING = 223269880;
 
-    INJECTED_KERNELS_DEPRECATED = 7;
+    FIELD_VALUE_OVERRIDEN = 309644133;
 
-    MISSING_TYPE_DEPENDENCY = 8;
+    INJECTED_KERNELS_DEPRECATED = 521934225;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 9;
+    MISSING_TYPE_DEPENDENCY = 244389774;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 10;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 40620624;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 11;
+    NEXT_HOP_CANNOT_IP_FORWARD = 450576044;
 
-    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 12;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 192249033;
 
-    NEXT_HOP_NOT_RUNNING = 13;
+    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 164687496;
 
-    NOT_CRITICAL_ERROR = 14;
+    NEXT_HOP_NOT_RUNNING = 320570614;
 
-    NO_RESULTS_ON_PAGE = 15;
+    NOT_CRITICAL_ERROR = 482982538;
 
-    REQUIRED_TOS_AGREEMENT = 16;
+    NO_RESULTS_ON_PAGE = 473516641;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 17;
+    REQUIRED_TOS_AGREEMENT = 470230240;
 
-    RESOURCE_NOT_DELETED = 18;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 397635400;
 
-    SCHEMA_VALIDATION_IGNORED = 19;
+    RESOURCE_NOT_DELETED = 356619127;
 
-    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 20;
+    SCHEMA_VALIDATION_IGNORED = 101514569;
 
-    UNDECLARED_PROPERTIES = 21;
+    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 369082522;
 
-    UNREACHABLE = 22;
+    UNDECLARED_PROPERTIES = 48814179;
+
+    UNREACHABLE = 135883734;
 
   }
 
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
-  Code code = 1;
+  Code code = 382397;
 
   // [Output Only] Metadata about this warning in key: value format. For example:
   // "data": [ { "key": "scope", "value": "zones/us-east1-d" }
-  repeated Data data = 2;
+  repeated Data data = 384501;
 
   // [Output Only] A human-readable description of the warning code.
-  string message = 3;
+  string message = 119365632;
 
 }
 
@@ -265,82 +283,85 @@ message Warnings {
 message Operation {
   // [Output Only] The status of the operation, which can be one of the following: PENDING, RUNNING, or DONE.
   enum Status {
-    DONE = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_STATUS = 0;
 
-    PENDING = 1;
+    DONE = 263024;
 
-    RUNNING = 2;
+    PENDING = 4424366;
+
+    RUNNING = 283595827;
 
   }
 
   // [Output Only] The value of `requestId` if you provided it in the request. Not present otherwise.
-  string client_operation_id = 1;
+  string client_operation_id = 506917084;
 
   // [Deprecated] This field is deprecated.
-  string creation_timestamp = 2;
+  string creation_timestamp = 70924534;
 
   // [Output Only] A textual description of the operation, which is set when the operation is created.
-  string description = 3;
+  string description = 321302655;
 
   // [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-  string end_time = 4;
+  string end_time = 215693942;
 
   // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-  Error error = 5;
+  Error error = 12098113;
 
   // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as NOT FOUND.
-  string http_error_message = 6;
+  string http_error_message = 159532971;
 
   // [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a 404 means the resource was not found.
-  int32 http_error_status_code = 7;
+  int32 http_error_status_code = 173260877;
 
   // [Output Only] The unique identifier for the operation. This identifier is defined by the server.
-  string id = 8;
+  string id = 419;
 
   // [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
-  string insert_time = 9;
+  string insert_time = 523977362;
 
   // [Output Only] Type of the resource. Always compute#operation for Operation resources.
-  string kind = 10;
+  string kind = 411506;
 
   // [Output Only] Name of the operation.
-  string name = 11;
+  string name = 421713;
 
   // [Output Only] The type of operation, such as insert, update, or delete, and so on.
-  string operation_type = 12;
+  string operation_type = 357750626;
 
   // [Output Only] An optional progress indicator that ranges from 0 to 100. There is no requirement that this be linear or support any granularity of operations. This should not be used to guess when the operation will be complete. This number should monotonically increase as the operation progresses.
-  int32 progress = 13;
+  int32 progress = 411736133;
 
   // [Output Only] The URL of the region where the operation resides. Only applicable when performing regional operations.
-  string region = 14;
+  string region = 420021470;
 
   // [Output Only] Server-defined URL for the resource.
-  string self_link = 15;
+  string self_link = 325462305;
 
   // [Output Only] The time that this operation was started by the server. This value is in RFC3339 text format.
-  string start_time = 16;
+  string start_time = 340227729;
 
   // [Output Only] The status of the operation, which can be one of the following: PENDING, RUNNING, or DONE.
-  Status status = 17;
+  Status status = 425310718;
 
   // [Output Only] An optional textual description of the current status of the operation.
-  string status_message = 18;
+  string status_message = 506940567;
 
   // [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
-  string target_id = 19;
+  string target_id = 434923857;
 
   // [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
-  string target_link = 20;
+  string target_link = 276269373;
 
   // [Output Only] User who requested the operation, for example: user@example.com.
-  string user = 21;
+  string user = 449913;
 
   // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-  repeated Warnings warnings = 22;
+  repeated Warnings warnings = 62261386;
 
   // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
-  string zone = 23;
+  string zone = 468085;
 
 }
 
@@ -348,115 +369,112 @@ message Operation {
 message Warning {
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
   enum Code {
-    CLEANUP_FAILED = 0;
+    // A dummy enum value indicating that the enum field is not set.
+    UNDEFINED_CODE = 0;
 
-    DEPRECATED_RESOURCE_USED = 1;
+    CLEANUP_FAILED = 18788555;
 
-    DEPRECATED_TYPE_USED = 2;
+    DEPRECATED_RESOURCE_USED = 48979448;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 3;
+    DEPRECATED_TYPE_USED = 110424642;
 
-    EXPERIMENTAL_TYPE_USED = 4;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 381724690;
 
-    EXTERNAL_API_WARNING = 5;
+    EXPERIMENTAL_TYPE_USED = 56494305;
 
-    FIELD_VALUE_OVERRIDEN = 6;
+    EXTERNAL_API_WARNING = 223269880;
 
-    INJECTED_KERNELS_DEPRECATED = 7;
+    FIELD_VALUE_OVERRIDEN = 309644133;
 
-    MISSING_TYPE_DEPENDENCY = 8;
+    INJECTED_KERNELS_DEPRECATED = 521934225;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 9;
+    MISSING_TYPE_DEPENDENCY = 244389774;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 10;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 40620624;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 11;
+    NEXT_HOP_CANNOT_IP_FORWARD = 450576044;
 
-    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 12;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 192249033;
 
-    NEXT_HOP_NOT_RUNNING = 13;
+    NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 164687496;
 
-    NOT_CRITICAL_ERROR = 14;
+    NEXT_HOP_NOT_RUNNING = 320570614;
 
-    NO_RESULTS_ON_PAGE = 15;
+    NOT_CRITICAL_ERROR = 482982538;
 
-    REQUIRED_TOS_AGREEMENT = 16;
+    NO_RESULTS_ON_PAGE = 473516641;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 17;
+    REQUIRED_TOS_AGREEMENT = 470230240;
 
-    RESOURCE_NOT_DELETED = 18;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 397635400;
 
-    SCHEMA_VALIDATION_IGNORED = 19;
+    RESOURCE_NOT_DELETED = 356619127;
 
-    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 20;
+    SCHEMA_VALIDATION_IGNORED = 101514569;
 
-    UNDECLARED_PROPERTIES = 21;
+    SINGLE_INSTANCE_PROPERTY_TEMPLATE = 369082522;
 
-    UNREACHABLE = 22;
+    UNDECLARED_PROPERTIES = 48814179;
+
+    UNREACHABLE = 135883734;
 
   }
 
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
-  Code code = 1;
+  Code code = 382397;
 
   // [Output Only] Metadata about this warning in key: value format. For example:
   // "data": [ { "key": "scope", "value": "zones/us-east1-d" }
-  repeated Data data = 2;
+  repeated Data data = 384501;
 
   // [Output Only] A human-readable description of the warning code.
-  string message = 3;
+  string message = 119365632;
 
 }
 
 // Contains a list of addresses.
 message AddressList {
   // [Output Only] Unique identifier for the resource; defined by the server.
-  string id = 1;
+  string id = 419;
 
   // A list of Address resources.
-  repeated Address items = 2;
+  repeated Address items = 12565752;
 
   // [Output Only] Type of resource. Always compute#addressList for lists of addresses.
-  string kind = 3;
+  string kind = 411506;
 
   // [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
-  string next_page_token = 4;
+  string next_page_token = 345519010;
 
   // [Output Only] Server-defined URL for this resource.
-  string self_link = 5;
+  string self_link = 325462305;
 
   // [Output Only] Informational warning message.
-  Warning warning = 6;
+  Warning warning = 140555763;
 
 }
 
 // A request message for Addresses.Insert. See the method description for details.
 message InsertAddressRequest {
+  Address address_resource = 328921471;
+
   // Project ID for this request.
-  string project = 1 [(google.api.field_behavior) = REQUIRED];
+  string project = 498207075 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the region for this request.
-  string region = 2 [(google.api.field_behavior) = REQUIRED];
+  string region = 420021470 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
   // For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments.
   //
   // The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-  string request_id = 3;
-
-  Address address_resource = 4;
+  string request_id = 4638745;
 
 }
 
 // A request message for Addresses.List. See the method description for details.
 message ListAddressesRequest {
-  // Project ID for this request.
-  string project = 1 [(google.api.field_behavior) = REQUIRED];
-
-  // Name of the region for this request.
-  string region = 2 [(google.api.field_behavior) = REQUIRED];
-
   // A filter expression that filters resources listed in the response. The expression must specify the field name, a comparison operator, and the value that you want to use for filtering. The value must be a string, a number, or a boolean. The comparison operator must be either =, !=, >, or <.
   //
   // For example, if you are filtering Compute Engine instances, you can exclude instances named example-instance by specifying name != example-instance.
@@ -464,20 +482,26 @@ message ListAddressesRequest {
   // You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
-  string filter = 3;
+  string filter = 377559407;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
-  uint32 max_results = 4;
+  uint32 max_results = 141057155;
 
   // Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.
   //
   // You can also sort results in descending order based on the creation timestamp using orderBy="creationTimestamp desc". This sorts results based on the creationTimestamp field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.
   //
   // Currently, only sorting by name or creationTimestamp desc is supported.
-  string order_by = 5;
+  string order_by = 154288093;
 
   // Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
-  string page_token = 6;
+  string page_token = 203825929;
+
+  // Project ID for this request.
+  string project = 498207075 [(google.api.field_behavior) = REQUIRED];
+
+  // Name of the region for this request.
+  string region = 420021470 [(google.api.field_behavior) = REQUIRED];
 
 }
 

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -41,7 +41,7 @@ option ruby_package = "Google::Cloud::Compute::V1";
 message Address {
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
   enum AddressType {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_ADDRESS_TYPE = 0;
 
     EXTERNAL = 35607499;
@@ -54,7 +54,7 @@ message Address {
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
   enum IpVersion {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_IP_VERSION = 0;
 
     IPV4 = 2254341;
@@ -69,7 +69,7 @@ message Address {
   //
   // If this field is not specified, it is assumed to be PREMIUM.
   enum NetworkTier {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
     PREMIUM = 399530551;
@@ -84,7 +84,7 @@ message Address {
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
   enum Purpose {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_PURPOSE = 0;
 
     DNS_RESOLVER = 476114556;
@@ -99,7 +99,7 @@ message Address {
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
   enum Status {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
     IN_USE = 17393485;
@@ -203,7 +203,7 @@ message Data {
 message Warnings {
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
   enum Code {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_CODE = 0;
 
     CLEANUP_FAILED = 150308440;
@@ -283,7 +283,7 @@ message Warnings {
 message Operation {
   // [Output Only] The status of the operation, which can be one of the following: PENDING, RUNNING, or DONE.
   enum Status {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
     DONE = 2104194;
@@ -369,7 +369,7 @@ message Operation {
 message Warning {
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
   enum Code {
-    // A dummy enum value indicating that the enum field is not set.
+    // A value indicating that the enum field is not set.
     UNDEFINED_CODE = 0;
 
     CLEANUP_FAILED = 150308440;


### PR DESCRIPTION
This change also moves the primitives message definitions from Field to Message class (where it should have been declared in the first place). 

The hashing function is slightly different from original (please check the updated design doc for details).