### PR TITLE
fix: use 2^28 for protobuf hash

### DIFF
--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
@@ -92,18 +92,16 @@ public class Message extends ProtoElement {
   // All the "magic numbers" come from the proto3 spec:
   // https://developers.google.com/protocol-buffers/docs/proto3#assigning_field_numbers
   private int getFieldNumber(String fieldName) {
-    // TODO: Use 2^29 instead of 2^28 once the following is fixed:
-    // https://github.com/protocolbuffers/protobuf/issues/8114
-    int fieldNumber = (fieldName.hashCode() << 4) >>> 4;
+    int fieldNumber = (fieldName.hashCode() << 3) >>> 3;
     if (fieldNumber == 0 || (fieldNumber >= 19000 && fieldNumber <= 19999)) {
-      fieldNumber = 20000 + ((fieldNumber % 19000) + 1) * 268147;
+      fieldNumber = 20000 + ((fieldNumber % 19000) + 1) * 536314;
     }
     return fieldNumber;
   }
 
   private int incrementFieldNumber(int fieldNumber) {
     int incrementedFieldNumber = fieldNumber + 1;
-    if ((fieldNumber >= 19000 && fieldNumber <= 19999) || fieldNumber >= (1 << 28)) {
+    if ((fieldNumber >= 19000 && fieldNumber <= 19999) || fieldNumber >= (1 << 29)) {
       incrementedFieldNumber = 20000;
     }
     return incrementedFieldNumber;

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -49,17 +49,17 @@ message Errors {
   optional string code = 3059181;
 
   // [Output Only] Indicates the field in the request that caused the error. This property is optional.
-  optional string location = 21995445;
+  optional string location = 290430901;
 
   // [Output Only] An optional, human-readable error message.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
 message Error {
   // [Output Only] The array of errors encountered while processing this operation.
-  repeated Errors errors = 47542123;
+  repeated Errors errors = 315977579;
 
 }
 
@@ -82,31 +82,31 @@ message Warnings {
 
     CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 123400130;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 78090774;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 101007511;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 183518987;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
     EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 61233967;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 148941963;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    MISSING_TYPE_DEPENDENCY = 76070007;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 56529543;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 114947431;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 195814990;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
     NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 148645809;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
     NOT_CRITICAL_ERROR = 105763924;
 
@@ -114,15 +114,15 @@ message Warnings {
 
     REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 228293185;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
     RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 6810186;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
     SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 122077983;
+    UNDECLARED_PROPERTIES = 390513439;
 
     UNREACHABLE = 13328052;
 
@@ -136,7 +136,7 @@ message Warnings {
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -169,13 +169,13 @@ message Operation {
   }
 
   // [Output Only] The value of `requestId` if you provided it in the request. Not present otherwise.
-  optional string client_operation_id = 28804839;
+  optional string client_operation_id = 297240295;
 
   // [Deprecated] This field is deprecated.
   optional string creation_timestamp = 30525366;
 
   // [Output Only] A textual description of the operation, which is set when the operation is created.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
   optional string end_time = 114938801;
@@ -187,13 +187,13 @@ message Operation {
   optional string http_error_message = 202521945;
 
   // [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a 404 means the resource was not found.
-  optional int32 http_error_status_code = 43909740;
+  optional int32 http_error_status_code = 312345196;
 
   // [Output Only] The unique identifier for the operation. This identifier is defined by the server.
   optional string id = 3355;
 
   // [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
-  optional string insert_time = 165287059;
+  optional string insert_time = 433722515;
 
   // [Output Only] Type of the resource. Always compute#operation for Operation resources.
   optional string kind = 3292052;
@@ -211,7 +211,7 @@ message Operation {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The time that this operation was started by the server. This value is in RFC3339 text format.
   optional string start_time = 37467274;
@@ -220,7 +220,7 @@ message Operation {
   optional Status status = 181260274;
 
   // [Output Only] An optional textual description of the current status of the operation.
-  optional string status_message = 28992698;
+  optional string status_message = 297428154;
 
   // [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
   optional string target_id = 258165385;
@@ -232,7 +232,7 @@ message Operation {
   optional string user = 3599307;
 
   // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-  repeated Warnings warnings = 229655639;
+  repeated Warnings warnings = 498091095;
 
   // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
   optional string zone = 3744684;
@@ -262,7 +262,7 @@ message Address {
 
     EXTERNAL = 35607499;
 
-    INTERNAL = 10860221;
+    INTERNAL = 279295677;
 
     UNSPECIFIED_TYPE = 53933922;
 
@@ -288,9 +288,9 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
@@ -303,13 +303,13 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_PURPOSE = 0;
 
-    DNS_RESOLVER = 207679100;
+    DNS_RESOLVER = 476114556;
 
     GCE_ENDPOINT = 230515243;
 
     NAT_AUTO = 163666477;
 
-    VPC_PEERING = 132364714;
+    VPC_PEERING = 400800170;
 
   }
 
@@ -320,14 +320,14 @@ message Address {
 
     IN_USE = 17393485;
 
-    RESERVED = 163805992;
+    RESERVED = 432241448;
 
-    RESERVING = 246151769;
+    RESERVING = 514587225;
 
   }
 
   // The static IP address represented by this resource.
-  optional string address = 194485236;
+  optional string address = 462920692;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
   optional AddressType address_type = 264307877;
@@ -336,13 +336,13 @@ message Address {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  optional IpVersion ip_version = 26524096;
+  optional IpVersion ip_version = 294959552;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
   optional string kind = 3292052;
@@ -356,29 +356,29 @@ message Address {
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  optional NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 517397843;
 
   // The prefix length if the resource reprensents an IP range.
-  optional int32 prefix_length = 185130291;
+  optional int32 prefix_length = 453565747;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
   // - `DNS_RESOLVER` for a DNS resolver address in a subnetwork
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
-  optional Purpose purpose = 47971614;
+  optional Purpose purpose = 316407070;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
   optional Status status = 181260274;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
   // [Output Only] The URLs of the resources that are using this address.
   repeated string users = 111578632;
@@ -388,7 +388,7 @@ message Address {
 //
 message AddressesScopedList {
   // [Output Only] A list of addresses contained in this scope.
-  repeated Address addresses = 69237666;
+  repeated Address addresses = 337673122;
 
   // [Output Only] Informational warning which replaces the list of addresses when the list is empty.
   optional Warning warning = 50704284;
@@ -404,31 +404,31 @@ message Warning {
 
     CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 123400130;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 78090774;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 101007511;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 183518987;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
     EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 61233967;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 148941963;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    MISSING_TYPE_DEPENDENCY = 76070007;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 56529543;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 114947431;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 195814990;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
     NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 148645809;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
     NOT_CRITICAL_ERROR = 105763924;
 
@@ -436,15 +436,15 @@ message Warning {
 
     REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 228293185;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
     RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 6810186;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
     SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 122077983;
+    UNDECLARED_PROPERTIES = 390513439;
 
     UNREACHABLE = 13328052;
 
@@ -458,7 +458,7 @@ message Warning {
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -477,7 +477,7 @@ message AddressAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -499,7 +499,7 @@ message AddressList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -515,10 +515,10 @@ message AggregatedListAddressesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -541,7 +541,7 @@ message AggregatedListAddressesRequest {
 // A request message for Addresses.Insert. See the method description for details.
 message InsertAddressRequest {
   // The body resource for this request
-  Address address_resource = 215452665 [(google.api.field_behavior) = REQUIRED];
+  Address address_resource = 483888121 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -567,7 +567,7 @@ message ListAddressesRequest {
   // You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
   optional uint32 max_results = 54715419;

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
@@ -66,7 +66,7 @@ message Address {
 
     EXTERNAL = 35607499;
 
-    INTERNAL = 10860221;
+    INTERNAL = 279295677;
 
     UNSPECIFIED_TYPE = 53933922;
 
@@ -92,9 +92,9 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
@@ -107,13 +107,13 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_PURPOSE = 0;
 
-    DNS_RESOLVER = 207679100;
+    DNS_RESOLVER = 476114556;
 
     GCE_ENDPOINT = 230515243;
 
     NAT_AUTO = 163666477;
 
-    VPC_PEERING = 132364714;
+    VPC_PEERING = 400800170;
 
   }
 
@@ -124,14 +124,14 @@ message Address {
 
     IN_USE = 17393485;
 
-    RESERVED = 163805992;
+    RESERVED = 432241448;
 
-    RESERVING = 246151769;
+    RESERVING = 514587225;
 
   }
 
   // The static IP address represented by this resource.
-  optional string address = 194485236;
+  optional string address = 462920692;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
   optional AddressType address_type = 264307877;
@@ -140,13 +140,13 @@ message Address {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  optional IpVersion ip_version = 26524096;
+  optional IpVersion ip_version = 294959552;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
   optional string kind = 3292052;
@@ -160,29 +160,29 @@ message Address {
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  optional NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 517397843;
 
   // The prefix length if the resource reprensents an IP range.
-  optional int32 prefix_length = 185130291;
+  optional int32 prefix_length = 453565747;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
   // - `DNS_RESOLVER` for a DNS resolver address in a subnetwork
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
-  optional Purpose purpose = 47971614;
+  optional Purpose purpose = 316407070;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
   optional Status status = 181260274;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
   // [Output Only] The URLs of the resources that are using this address.
   repeated string users = 111578632;


### PR DESCRIPTION
Once [this PR](https://github.com/protocolbuffers/protobuf/pull/8235) is merge and tagged, we can merge this, which reverts #16 



