### PR TITLE
feat: Generate most of the fields as `optional`

### DIFF
--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Field.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Field.java
@@ -20,18 +20,26 @@ import java.util.List;
 import java.util.Objects;
 
 public class Field extends ProtoElement {
+  private static int COUNTER = 0;
   private final String name;
   private Message valueType;
   private final boolean repeated;
+  private final boolean optional;
   private Message keyType;
   private final List<Option> options = new ArrayList<>();
 
   public Field(
-      String name, Message valueType, boolean repeated, Message keyType, String description) {
+      String name,
+      Message valueType,
+      boolean repeated,
+      boolean optional,
+      Message keyType,
+      String description) {
     super(description);
     this.name = name;
     this.valueType = valueType;
     this.repeated = repeated;
+    this.optional = optional;
     this.keyType = keyType;
   }
 
@@ -49,6 +57,10 @@ public class Field extends ProtoElement {
 
   public boolean isRepeated() {
     return repeated;
+  }
+
+  public boolean isOptional() {
+    return optional;
   }
 
   public void setKeyType(Message keyType) {
@@ -97,6 +109,9 @@ public class Field extends ProtoElement {
         sb.append("repeated ").append(valueType);
       }
     } else {
+      if (optional) {
+        sb.append("optional ");
+      }
       sb.append(valueType);
     }
     if (sb.length() > 0) {

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Field.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Field.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Objects;
 
 public class Field extends ProtoElement {
-  private static int COUNTER = 0;
   private final String name;
   private Message valueType;
   private final boolean repeated;

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -46,13 +46,13 @@ option ruby_package = "Google::Cloud::Compute::V1";
 //
 message Errors {
   // [Output Only] The error type identifier for this error.
-  string code = 3059181;
+  optional string code = 3059181;
 
   // [Output Only] Indicates the field in the request that caused the error. This property is optional.
-  string location = 21995445;
+  optional string location = 21995445;
 
   // [Output Only] An optional, human-readable error message.
-  string message = 149618695;
+  optional string message = 149618695;
 
 }
 
@@ -66,10 +66,10 @@ message Error {
 //
 message Data {
   // [Output Only] A key that provides more detail on the warning being returned. For example, for warnings where there are no results in a list request for a particular zone, this key might be scope and the key value might be the zone name. Other examples might be a key indicating a deprecated resource and a suggested replacement, or a warning about invalid network settings (for example, if an instance attempts to perform IP forwarding but is not enabled for IP forwarding).
-  string key = 106079;
+  optional string key = 106079;
 
   // [Output Only] A warning data value corresponding to the key.
-  string value = 111972721;
+  optional string value = 111972721;
 
 }
 
@@ -129,14 +129,14 @@ message Warnings {
   }
 
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
-  Code code = 3059181;
+  optional Code code = 3059181;
 
   // [Output Only] Metadata about this warning in key: value format. For example:
   // "data": [ { "key": "scope", "value": "zones/us-east1-d" }
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  string message = 149618695;
+  optional string message = 149618695;
 
 }
 
@@ -169,73 +169,73 @@ message Operation {
   }
 
   // [Output Only] The value of `requestId` if you provided it in the request. Not present otherwise.
-  string client_operation_id = 28804839;
+  optional string client_operation_id = 28804839;
 
   // [Deprecated] This field is deprecated.
-  string creation_timestamp = 30525366;
+  optional string creation_timestamp = 30525366;
 
   // [Output Only] A textual description of the operation, which is set when the operation is created.
-  string description = 154502140;
+  optional string description = 154502140;
 
   // [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
-  string end_time = 114938801;
+  optional string end_time = 114938801;
 
   // [Output Only] If errors are generated during processing of the operation, this field will be populated.
-  Error error = 96784904;
+  optional Error error = 96784904;
 
   // [Output Only] If the operation fails, this field contains the HTTP error message that was returned, such as NOT FOUND.
-  string http_error_message = 202521945;
+  optional string http_error_message = 202521945;
 
   // [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a 404 means the resource was not found.
-  int32 http_error_status_code = 43909740;
+  optional int32 http_error_status_code = 43909740;
 
   // [Output Only] The unique identifier for the operation. This identifier is defined by the server.
-  string id = 3355;
+  optional string id = 3355;
 
   // [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
-  string insert_time = 165287059;
+  optional string insert_time = 165287059;
 
   // [Output Only] Type of the resource. Always compute#operation for Operation resources.
-  string kind = 3292052;
+  optional string kind = 3292052;
 
   // [Output Only] Name of the operation.
-  string name = 3373707;
+  optional string name = 3373707;
 
   // [Output Only] The type of operation, such as insert, update, or delete, and so on.
-  string operation_type = 177650450;
+  optional string operation_type = 177650450;
 
   // [Output Only] An optional progress indicator that ranges from 0 to 100. There is no requirement that this be linear or support any granularity of operations. This should not be used to guess when the operation will be complete. This number should monotonically increase as the operation progresses.
-  int32 progress = 72663597;
+  optional int32 progress = 72663597;
 
   // [Output Only] The URL of the region where the operation resides. Only applicable when performing regional operations.
-  string region = 138946292;
+  optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  string self_link = 187779341;
+  optional string self_link = 187779341;
 
   // [Output Only] The time that this operation was started by the server. This value is in RFC3339 text format.
-  string start_time = 37467274;
+  optional string start_time = 37467274;
 
   // [Output Only] The status of the operation, which can be one of the following: PENDING, RUNNING, or DONE.
-  Status status = 181260274;
+  optional Status status = 181260274;
 
   // [Output Only] An optional textual description of the current status of the operation.
-  string status_message = 28992698;
+  optional string status_message = 28992698;
 
   // [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
-  string target_id = 258165385;
+  optional string target_id = 258165385;
 
   // [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
-  string target_link = 62671336;
+  optional string target_link = 62671336;
 
   // [Output Only] User who requested the operation, for example: user@example.com.
-  string user = 3599307;
+  optional string user = 3599307;
 
   // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
   repeated Warnings warnings = 229655639;
 
   // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
-  string zone = 3744684;
+  optional string zone = 3744684;
 
 }
 
@@ -327,58 +327,58 @@ message Address {
   }
 
   // The static IP address represented by this resource.
-  string address = 194485236;
+  optional string address = 194485236;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
-  AddressType address_type = 264307877;
+  optional AddressType address_type = 264307877;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
-  string creation_timestamp = 30525366;
+  optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  string description = 154502140;
+  optional string description = 154502140;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
-  string id = 3355;
+  optional string id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  IpVersion ip_version = 26524096;
+  optional IpVersion ip_version = 26524096;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
-  string kind = 3292052;
+  optional string kind = 3292052;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?`. The first character must be a lowercase letter, and all following characters (except for the last character) must be a dash, lowercase letter, or digit. The last character must be a lowercase letter or digit.
-  string name = 3373707;
+  optional string name = 3373707;
 
   // The URL of the network in which to reserve the address. This field can only be used with INTERNAL type with the VPC_PEERING purpose.
-  string network = 232872494;
+  optional string network = 232872494;
 
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 248962387;
 
   // The prefix length if the resource reprensents an IP range.
-  int32 prefix_length = 185130291;
+  optional int32 prefix_length = 185130291;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
   // - `DNS_RESOLVER` for a DNS resolver address in a subnetwork
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
-  Purpose purpose = 47971614;
+  optional Purpose purpose = 47971614;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
-  string region = 138946292;
+  optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  string self_link = 187779341;
+  optional string self_link = 187779341;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
-  Status status = 181260274;
+  optional Status status = 181260274;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  string subnetwork = 39392238;
+  optional string subnetwork = 39392238;
 
   // [Output Only] The URLs of the resources that are using this address.
   repeated string users = 111578632;
@@ -391,7 +391,7 @@ message AddressesScopedList {
   repeated Address addresses = 69237666;
 
   // [Output Only] Informational warning which replaces the list of addresses when the list is empty.
-  Warning warning = 50704284;
+  optional Warning warning = 50704284;
 
 }
 
@@ -451,58 +451,58 @@ message Warning {
   }
 
   // [Output Only] A warning code, if applicable. For example, Compute Engine returns NO_RESULTS_ON_PAGE if there are no results in the response.
-  Code code = 3059181;
+  optional Code code = 3059181;
 
   // [Output Only] Metadata about this warning in key: value format. For example:
   // "data": [ { "key": "scope", "value": "zones/us-east1-d" }
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  string message = 149618695;
+  optional string message = 149618695;
 
 }
 
 //
 message AddressAggregatedList {
   // [Output Only] Unique identifier for the resource; defined by the server.
-  string id = 3355;
+  optional string id = 3355;
 
   // A list of AddressesScopedList resources.
   map<string, AddressesScopedList> items = 100526016;
 
   // [Output Only] Type of resource. Always compute#addressAggregatedList for aggregated lists of addresses.
-  string kind = 3292052;
+  optional string kind = 3292052;
 
   // [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
-  string next_page_token = 79797525;
+  optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  string self_link = 187779341;
+  optional string self_link = 187779341;
 
   // [Output Only] Informational warning message.
-  Warning warning = 50704284;
+  optional Warning warning = 50704284;
 
 }
 
 // Contains a list of addresses.
 message AddressList {
   // [Output Only] Unique identifier for the resource; defined by the server.
-  string id = 3355;
+  optional string id = 3355;
 
   // A list of Address resources.
   repeated Address items = 100526016;
 
   // [Output Only] Type of resource. Always compute#addressList for lists of addresses.
-  string kind = 3292052;
+  optional string kind = 3292052;
 
   // [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
-  string next_page_token = 79797525;
+  optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  string self_link = 187779341;
+  optional string self_link = 187779341;
 
   // [Output Only] Informational warning message.
-  Warning warning = 50704284;
+  optional Warning warning = 50704284;
 
 }
 
@@ -515,23 +515,23 @@ message AggregatedListAddressesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  string filter = 67685240;
+  optional string filter = 67685240;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 122892532;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
-  uint32 max_results = 54715419;
+  optional uint32 max_results = 54715419;
 
   // Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.
   //
   // You can also sort results in descending order based on the creation timestamp using `orderBy="creationTimestamp desc"`. This sorts results based on the `creationTimestamp` field in reverse chronological order (newest result first). Use this to sort resources like operations so that the newest operation is returned first.
   //
   // Currently, only sorting by `name` or `creationTimestamp desc` is supported.
-  string order_by = 160562920;
+  optional string order_by = 160562920;
 
   // Specifies a page token to use. Set `pageToken` to the `nextPageToken` returned by a previous list request to get the next page of results.
-  string page_token = 19994697;
+  optional string page_token = 19994697;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -554,7 +554,7 @@ message InsertAddressRequest {
   // For example, consider a situation where you make an initial request and the request times out. If you make the request again with the same request ID, the server can check if original operation with the same request ID was received, and if so, will ignore the second request. This prevents clients from accidentally creating duplicate commitments.
   //
   // The request ID must be a valid UUID with the exception that zero UUID is not supported (00000000-0000-0000-0000-000000000000).
-  string request_id = 37109963;
+  optional string request_id = 37109963;
 
 }
 
@@ -567,10 +567,10 @@ message ListAddressesRequest {
   // You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
-  string filter = 67685240;
+  optional string filter = 67685240;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
-  uint32 max_results = 54715419;
+  optional uint32 max_results = 54715419;
 
   // Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.
   //
@@ -580,7 +580,7 @@ message ListAddressesRequest {
   string order_by = 160562920 [(google.api.field_behavior) = REQUIRED];
 
   // Specifies a page token to use. Set pageToken to the nextPageToken returned by a previous list request to get the next page of results.
-  string page_token = 19994697;
+  optional string page_token = 19994697;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
@@ -131,58 +131,58 @@ message Address {
   }
 
   // The static IP address represented by this resource.
-  string address = 194485236;
+  optional string address = 194485236;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
-  AddressType address_type = 264307877;
+  optional AddressType address_type = 264307877;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
-  string creation_timestamp = 30525366;
+  optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  string description = 154502140;
+  optional string description = 154502140;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
-  string id = 3355;
+  optional string id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  IpVersion ip_version = 26524096;
+  optional IpVersion ip_version = 26524096;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
-  string kind = 3292052;
+  optional string kind = 3292052;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?`. The first character must be a lowercase letter, and all following characters (except for the last character) must be a dash, lowercase letter, or digit. The last character must be a lowercase letter or digit.
-  string name = 3373707;
+  optional string name = 3373707;
 
   // The URL of the network in which to reserve the address. This field can only be used with INTERNAL type with the VPC_PEERING purpose.
-  string network = 232872494;
+  optional string network = 232872494;
 
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 248962387;
 
   // The prefix length if the resource reprensents an IP range.
-  int32 prefix_length = 185130291;
+  optional int32 prefix_length = 185130291;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
   // - `DNS_RESOLVER` for a DNS resolver address in a subnetwork
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
-  Purpose purpose = 47971614;
+  optional Purpose purpose = 47971614;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
-  string region = 138946292;
+  optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  string self_link = 187779341;
+  optional string self_link = 187779341;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
-  Status status = 181260274;
+  optional Status status = 181260274;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  string subnetwork = 39392238;
+  optional string subnetwork = 39392238;
 
   // [Output Only] The URLs of the resources that are using this address.
   repeated string users = 111578632;


### PR DESCRIPTION
This is to support default value policy as per DIREGAPIC design.
`optional` fields is applied to **all fields unless** they are :
- of type `repeated` (invalid protobuf syntax)
- of type `map` (invalid protobuf syntax)
- have `field_behavior=REQUIRED` annotation assigned

This change also assumes taht a fix in protobuf itself for java stub generation is accepted and pushed [java_message.cc#L216](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/java/java_message.cc#L216), otherwise on full compute the generated java stubs will produce compilation error. More details in the internal CL in protobuf.