### PR TITLE
fix: Support field names starting with a capital letter.

### DIFF
--- a/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
@@ -143,9 +143,10 @@ public class Name {
 
   /**
    * Returns the identifier in lower-underscore format but with the first uppercase letter if the
-   * original identifier started with an uppercase letter.
+   * original identifier started with an uppercase letter. For example ipAddress will be converted
+   * to ip_address, but IpAddress will be converted to Ip_address.
    */
-  public String toUpperLowerUnderscore() {
+  public String toCapitalizedLowerUnderscore() {
     List<String> newPieces = new ArrayList<>();
     for (NamePiece namePiece : namePieces) {
       String newPiece = namePiece.caseFormat.to(CaseFormat.LOWER_UNDERSCORE, namePiece.identifier);

--- a/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
@@ -141,6 +141,23 @@ public class Name {
     return toUnderscore(CaseFormat.LOWER_UNDERSCORE);
   }
 
+  /**
+   * Returns the identifier in lower-underscore format but with the first uppercase letter if the
+   * original identifier started with an uppercase letter.
+   */
+  public String toUpperLowerUnderscor() {
+    List<String> newPieces = new ArrayList<>();
+    for (NamePiece namePiece : namePieces) {
+      String newPiece = namePiece.caseFormat.to(CaseFormat.LOWER_UNDERSCORE, namePiece.identifier);
+      if (newPieces.isEmpty() && Character.isUpperCase(namePiece.identifier.charAt(0))) {
+        newPiece = Character.toUpperCase(newPiece.charAt(0)) + newPiece.substring(1);
+      }
+      newPieces.add(newPiece);
+    }
+
+    return Joiner.on('_').join(newPieces);
+  }
+
   private String toUnderscore(CaseFormat caseFormat) {
     List<String> newPieces = new ArrayList<>();
     for (NamePiece namePiece : namePieces) {

--- a/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/disco/Name.java
@@ -145,7 +145,7 @@ public class Name {
    * Returns the identifier in lower-underscore format but with the first uppercase letter if the
    * original identifier started with an uppercase letter.
    */
-  public String toUpperLowerUnderscor() {
+  public String toUpperLowerUnderscore() {
     List<String> newPieces = new ArrayList<>();
     for (NamePiece namePiece : namePieces) {
       String newPiece = namePiece.caseFormat.to(CaseFormat.LOWER_UNDERSCORE, namePiece.identifier);

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
@@ -137,7 +137,7 @@ public class DocumentToProtoConverter {
   }
 
   private Field schemaToField(Schema sch, boolean optional) {
-    String name = Name.anyCamel(sch.key()).toUpperLowerUnderscore();
+    String name = Name.anyCamel(sch.key()).toCapitalizedLowerUnderscore();
     String description = sch.description();
     Message valueType = null;
     boolean repeated = false;

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
@@ -137,7 +137,7 @@ public class DocumentToProtoConverter {
   }
 
   private Field schemaToField(Schema sch, boolean optional) {
-    String name = Name.anyCamel(sch.key()).toLowerUnderscore();
+    String name = Name.anyCamel(sch.key()).toUpperLowerUnderscor();
     String description = sch.description();
     Message valueType = null;
     boolean repeated = false;

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
@@ -137,7 +137,7 @@ public class DocumentToProtoConverter {
   }
 
   private Field schemaToField(Schema sch, boolean optional) {
-    String name = Name.anyCamel(sch.key()).toUpperLowerUnderscor();
+    String name = Name.anyCamel(sch.key()).toUpperLowerUnderscore();
     String description = sch.description();
     Message valueType = null;
     boolean repeated = false;

--- a/src/test/resources/compute.v1.small.json
+++ b/src/test/resources/compute.v1.small.json
@@ -358,6 +358,10 @@
             ""
           ]
         },
+        "IPAddress": {
+         "type": "string",
+         "description": "IP address."
+        },
         "kind": {
           "type": "string",
           "description": "[Output Only] Type of the resource. Always compute#address for addresses.",

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -326,6 +326,9 @@ message Address {
 
   }
 
+  // IP address.
+  optional string I_p_address = 42976943;
+
   // The static IP address represented by this resource.
   optional string address = 462920692;
 

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
@@ -130,6 +130,9 @@ message Address {
 
   }
 
+  // IP address.
+  optional string I_p_address = 42976943;
+
   // The static IP address represented by this resource.
   optional string address = 462920692;
 


### PR DESCRIPTION
In GCE discovery API there are a few malformed field names starting with a capital letter, like `IPAddress`.

If converted to proto file as `ip_address` or `i_p_address` then in `JSON` it is serialized as `ipAddress` or `iPAddress` respectively, which would break `GlobalForwardingRulesClient.insert()` call. To be properly serialized into json as `IPAddress` in proto the field must be converted as `I_p_address`. See internal bug from a customer for more details.