### PR TITLE
fix!: convert discovery fields defined as `type: string` & `format: "int64"` (or `format: "uint64"`)  fields to `int64/uint64` proto fields

### DIFF
--- a/src/main/java/com/google/cloud/discotoproto3converter/disco/Schema.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/disco/Schema.java
@@ -260,7 +260,9 @@ public abstract class Schema implements Node {
     INT32("int32"),
     INT64("int64"),
     UINT32("uint32"),
-    UINT64("uint64");
+    UINT64("uint64"),
+    FIXED32("fixed32"),
+    FIXED64("fixed64");
 
     private String text;
 

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/DocumentToProtoConverter.java
@@ -168,6 +168,12 @@ public class DocumentToProtoConverter {
           case UINT64:
             valueType = Message.PRIMITIVES.get("uint64");
             break;
+          case FIXED32:
+            valueType = Message.PRIMITIVES.get("fixed32");
+            break;
+          case FIXED64:
+            valueType = Message.PRIMITIVES.get("fixed64");
+            break;
         }
         break;
       case NUMBER:
@@ -194,7 +200,20 @@ public class DocumentToProtoConverter {
               constructEnumMessage(
                   getMessageName(sch), description, sch.enumValues(), sch.enumDescriptions());
         } else {
-          valueType = Message.PRIMITIVES.get("string");
+          switch (sch.format()) {
+            case INT64:
+              valueType = Message.PRIMITIVES.get("int64");
+              break;
+            case UINT64:
+              valueType = Message.PRIMITIVES.get("uint64");
+              break;
+            case FIXED64:
+              valueType = Message.PRIMITIVES.get("fixed64");
+              break;
+            default:
+              valueType = Message.PRIMITIVES.get("string");
+              break;
+          }
         }
         break;
     }

--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Message.java
@@ -35,7 +35,7 @@ public class Message extends ProtoElement {
     PRIMITIVES.put("uint32", new Message("uint32", false, false, null));
     PRIMITIVES.put("int64", new Message("int64", false, false, null));
     PRIMITIVES.put("fixed64", new Message("fixed64", false, false, null));
-    PRIMITIVES.put("unit64", new Message("unit64", false, false, null));
+    PRIMITIVES.put("uint64", new Message("uint64", false, false, null));
     PRIMITIVES.put("float", new Message("float", false, false, null));
     PRIMITIVES.put("double", new Message("double", false, false, null));
     PRIMITIVES.put("", new Message("", false, true, null));

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.baseline
@@ -190,7 +190,7 @@ message Operation {
   optional int32 http_error_status_code = 312345196;
 
   // [Output Only] The unique identifier for the operation. This identifier is defined by the server.
-  optional string id = 3355;
+  optional uint64 id = 3355;
 
   // [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
   optional string insert_time = 433722515;
@@ -223,7 +223,7 @@ message Operation {
   optional string status_message = 297428154;
 
   // [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
-  optional string target_id = 258165385;
+  optional uint64 target_id = 258165385;
 
   // [Output Only] The URL of the resource that the operation modifies. For operations related to creating a snapshot, this points to the persistent disk that the snapshot was created from.
   optional string target_link = 62671336;
@@ -342,7 +342,7 @@ message Address {
   optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
-  optional string id = 3355;
+  optional uint64 id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
   optional IpVersion ip_version = 294959552;

--- a/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
+++ b/src/test/resources/google/cloud/compute/v1/compute.proto.ignorelist
@@ -146,7 +146,7 @@ message Address {
   optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
-  optional string id = 3355;
+  optional uint64 id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
   optional IpVersion ip_version = 294959552;


### PR DESCRIPTION
Those used to be converted as strings.