### PR TITLE
fix: guard against Null Pointer Exception

### DIFF
--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/ProtoMerger.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/ProtoMerger.java
@@ -125,9 +125,12 @@ public class ProtoMerger {
   // Despite message types having the same names, they are two independently created
   // sets of objects.
   private Field copyField(Field newField, Field oldField, Map<String, Message> newMessages) {
-    Message valueType = Message.PRIMITIVES.get(oldField.getValueType().getName());
-    if (valueType == null) {
-      valueType = newMessages.get(oldField.getValueType().getName());
+    Message valueType = null;
+    if (oldField.getValueType() != null) {
+      valueType = Message.PRIMITIVES.get(oldField.getValueType().getName());
+      if (valueType == null) {
+        valueType = newMessages.get(oldField.getValueType().getName());
+      }
     }
     Message keyType = null;
     if (oldField.getKeyType() != null) {


### PR DESCRIPTION
This is motivated by the DIREGAPIC generation failure [here]()https://github.com/googleapis/googleapis/actions/runs/6827288238/job/18569079226.