### PR TITLE
fix(temporary): reorder imports to work around protobuf.js problem

### DIFF
--- a/src/main/java/com/google/cloud/discotoproto3converter/proto3/Proto3Writer.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/proto3/Proto3Writer.java
@@ -45,6 +45,13 @@ public class Proto3Writer implements ConverterWriter {
 
     writer.println("package " + metadata.getProtoPkg() + ";\n");
 
+    // TODO: Place this import in the right alphabetical order. We are placing it here for now to
+    // work around an apparent bug in protobuf.js, where having this particular import be the last
+    // one makes the file not actually be imported.
+    if (protoFile.HasAnyFields()) {
+      writer.println("import \"google/protobuf/any.proto\";");
+    }
+
     writer.println("import \"google/api/annotations.proto\";");
     writer.println("import \"google/api/client.proto\";");
     writer.println("import \"google/api/field_behavior.proto\";");
@@ -52,9 +59,6 @@ public class Proto3Writer implements ConverterWriter {
 
     if (protoFile.isHasLroDefinitions()) {
       writer.println("import \"google/cloud/extended_operations.proto\";");
-    }
-    if (protoFile.HasAnyFields()) {
-      writer.println("import \"google/protobuf/any.proto\";");
     }
     writer.println();
 

--- a/src/test/resources/google/cloud/compute/v1small/compute.error-any.proto.baseline
+++ b/src/test/resources/google/cloud/compute/v1small/compute.error-any.proto.baseline
@@ -22,12 +22,12 @@ syntax = "proto3";
 
 package google.cloud.compute.v1small;
 
+import "google/protobuf/any.proto";
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
 import "google/cloud/extended_operations.proto";
-import "google/protobuf/any.proto";
 
 //
 // File Options


### PR DESCRIPTION
Apparently,  `protobuf.js` is not currently importing the `Any` type when `any.proto` is last in the import list, but the import does work if `any.proto` is higher in the import list. Pending a fix for this in `protobuf.js`, this change imports `any.proto` earlier to avoid triggering the problem. When `protobuf.js` is fixed, we can revert the change to maintain alphabetical ordering of imports.