### PR TITLE
feat: new discovery-converter-app that generates proto and config files in a  single invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,10 @@ RUN mvn package
 FROM eclipse-temurin:21
 WORKDIR /app
 
-# --- Robust Artifact Handling ---
-# Use an ARG to define the JAR path with a wildcard to avoid hardcoding versions.
-ARG JAR_FILE=target/disco-to-proto3-converter-*-jar-with-dependencies.jar
-
 # Copy the built JAR from the builder stage and give it a consistent name.
-COPY --from=builder /repo/${JAR_FILE} disco-to-proto3-converter.jar
+COPY --from=builder /repo/disco-to-proto3-converter-app.jar ./
+COPY --from=builder /repo/service-config-generator-app.jar ./
+COPY --from=builder /repo/gapic-yaml-generator-app.jar ./
 
 # Define the entrypoint to run the application.
-ENTRYPOINT ["java", "-jar", "disco-to-proto3-converter.jar"]
+ENTRYPOINT ["java", "-jar", "disco-to-proto3-converter-app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,10 +32,12 @@ RUN mvn package
 FROM eclipse-temurin:21
 WORKDIR /app
 
-# Copy the built JAR from the builder stage and give it a consistent name.
-COPY --from=builder /repo/disco-to-proto3-converter-app.jar ./
-COPY --from=builder /repo/service-config-generator-app.jar ./
-COPY --from=builder /repo/gapic-yaml-generator-app.jar ./
+# Copy the built JAR from the builder stage.
+COPY --from=builder /repo/discovery-converter-app.jar ./
+# To keep the Docker image as small as needed, we omit the
+# single-purpose converters `disco-to-proto3-converter-app.jar`,
+# `service-config-generator-app.jar`, and
+# `gapic-yaml-generator-app.jar`. They can be added when needed.
 
 # Define the entrypoint to run the application.
-ENTRYPOINT ["java", "-jar", "disco-to-proto3-converter-app.jar"]
+ENTRYPOINT ["java", "-jar", "discovery-converter-app.jar"]

--- a/README.md
+++ b/README.md
@@ -27,23 +27,22 @@ bazel run :google_java_format --enable_workspace
 ```
 
 ### Run
-After performing the build, to obtain the proto from the converter using
-`compute.v1.json` (included in this repository) as a sample input, run the
-following command from the repository root:
+After performing the build, you obtain the API protocol buffer file and GAPIC
+configuration files derived from the sample `compute.v1.json` Discovery file
+(included in this repository) by running the following command from the
+repository root:
 
 ```sh
 java \
-  -jar target/target/disco-to-proto3-converter-app.jar \
+  -jar target/target/discovery-converter-app.jar \
   --discovery_doc_path=src/test/resources/google/cloud/compute/v1/compute.v1.json \
-  --output_file_path=google/cloud/compute/v1/compute.- \
+  --output_file_path=google/cloud/compute/v1/compute \
   --input_config_path=src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
   --output_config_path=google/cloud/compute/v1/compute.v1.config.output.json \
   --enums_as_strings=True
 ```
 
-Note the `.-` suffix in the value of `--output_file_path`. This causes all three
-generated files (the proto and the config files) to be generated together. Check
-the `google/cloud/compute/v1` directory for the resulting `compute.proto`,
+Check the `google/cloud/compute/v1` directory for the resulting `compute.proto`,
 `compute_grpc_service_config.json`, and `compute_gapic.yaml` files.
 
 #### (Alternative) Generate each file individually
@@ -107,7 +106,7 @@ You can package the converter in a Docker image and run it as follows:
    ```sh
    docker run -v $(pwd):/apis converter:test \
      --discovery_doc_path=/apis/src/test/resources/google/cloud/compute/v1/compute.v1.json \
-     --output_file_path=/apis/google/cloud/compute/v1/compute.- \
+     --output_file_path=/apis/google/cloud/compute/v1/compute \
      --input_config_path=/apis/src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
      --output_config_path=/apis/google/cloud/compute/v1/compute.v1.config.output.json  \
      --enums_as_strings=True

--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ bazel run :google_java_format --enable_workspace
 ```
 
 ### Run
-After performing the build, to run the converter using `compute.v1.json` as a
-sample input (included in this repository) run the following command from the
-repository root:
+After performing the build, to obtain the proto from the converter using
+`compute.v1.json` (included in this repository) as a sample input, run the
+following command from the repository root:
+
 ```sh
 java \
-  -jar target/disco-to-proto3-converter-0.0.1-SNAPSHOT-jar-with-dependencies.jar \
+  -jar target/target/disco-to-proto3-converter-app.jar \
   --discovery_doc_path=src/test/resources/google/cloud/compute/v1/compute.v1.json \
   --output_file_path=google/cloud/compute/v1/compute.proto \
   --input_config_path=src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
@@ -42,6 +43,34 @@ java \
 
 Check the `google/cloud/compute/v1` directory for the converted `compute.proto`
 file.
+
+To get the corresponding auxiliary config files, run
+
+```sh
+java \
+  -jar target/service-config-generator-app.jar \
+  --discovery_doc_path=src/test/resources/google/cloud/compute/v1/compute.v1.json \
+  --output_file_path=google/cloud/compute/v1/compute_grpc_service_config.json \
+  --input_config_path=src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
+  --output_config_path=google/cloud/compute/v1/compute.v1.config.output.json \
+  --enums_as_strings=True
+```
+
+and
+
+```sh
+java \
+  -jar target/gapic-yaml-generator-app.jar \
+  --discovery_doc_path=src/test/resources/google/cloud/compute/v1/compute.v1.json \
+  --output_file_path=google/cloud/compute/v1/compute_gapic.yaml \
+  --input_config_path=src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
+  --output_config_path=google/cloud/compute/v1/compute.v1.config.output.json \
+  --enums_as_strings=True
+```
+
+The config files generated from these example invocations,
+`compute_grpc_service_config.json` and `compute_gapic.yaml`, respectively, will
+also appear in the `google/cloud/compute/v1` directory.
 
 
 ### Docker

--- a/README.md
+++ b/README.md
@@ -35,16 +35,33 @@ following command from the repository root:
 java \
   -jar target/target/disco-to-proto3-converter-app.jar \
   --discovery_doc_path=src/test/resources/google/cloud/compute/v1/compute.v1.json \
+  --output_file_path=google/cloud/compute/v1/compute.- \
+  --input_config_path=src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
+  --output_config_path=google/cloud/compute/v1/compute.v1.config.output.json \
+  --enums_as_strings=True
+```
+
+Note the `.-` suffix in the value of `--output_file_path`. This causes all three
+generated files (the proto and the config files) to be generated together. Check
+the `google/cloud/compute/v1` directory for the resulting `compute.proto`,
+`compute_grpc_service_config.json`, and `compute_gapic.yaml` files.
+
+#### (Alternative) Generate each file individually
+You can also generate each of the files above individually by using distinct generator binaries for each.
+
+* To generate just `compute.proto`, run:
+
+```sh
+java \
+  -jar target/target/disco-to-proto3-converter-app.jar \
+  --discovery_doc_path=src/test/resources/google/cloud/compute/v1/compute.v1.json \
   --output_file_path=google/cloud/compute/v1/compute.proto \
   --input_config_path=src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
   --output_config_path=google/cloud/compute/v1/compute.v1.config.output.json \
   --enums_as_strings=True
 ```
 
-Check the `google/cloud/compute/v1` directory for the converted `compute.proto`
-file.
-
-To get the corresponding auxiliary config files, run
+To generate just `compute_grpc_service_config.json`, run:
 
 ```sh
 java \
@@ -56,7 +73,7 @@ java \
   --enums_as_strings=True
 ```
 
-and
+To generate just `compute_gapic.yaml`, run:
 
 ```sh
 java \
@@ -67,10 +84,6 @@ java \
   --output_config_path=google/cloud/compute/v1/compute.v1.config.output.json \
   --enums_as_strings=True
 ```
-
-The config files generated from these example invocations,
-`compute_grpc_service_config.json` and `compute_gapic.yaml`, respectively, will
-also appear in the `google/cloud/compute/v1` directory.
 
 
 ### Docker
@@ -94,7 +107,7 @@ You can package the converter in a Docker image and run it as follows:
    ```sh
    docker run -v $(pwd):/apis converter:test \
      --discovery_doc_path=/apis/src/test/resources/google/cloud/compute/v1/compute.v1.json \
-     --output_file_path=/apis/google/cloud/compute/v1/compute.proto \
+     --output_file_path=/apis/google/cloud/compute/v1/compute.- \
      --input_config_path=/apis/src/test/resources/google/cloud/compute/v1/compute.v1.config.input.json \
      --output_config_path=/apis/google/cloud/compute/v1/compute.v1.config.output.json  \
      --enums_as_strings=True

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 
           <!-- Execution #1: DiscoToProto3ConverterApp -->
           <execution>
-            <id>shade-disco-converter</id>
+            <id>shade-proto3-generator</id>
             <phase>package</phase>
             <goals>
               <goal>shade</goal>
@@ -169,10 +169,41 @@
               </filters>
             </configuration>
           </execution>
-          
+
+          <!-- Execution #4: DiscoveryConverterApp -->
+          <execution>
+            <id>shade-discovery-converter</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <!-- The final name for the fourth binary -->
+              <finalName>discovery-converter-app</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <!-- The main class for the fourth binary -->
+                  <mainClass>com.google.cloud.discotoproto3converter.DiscoveryConverterApp</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <!-- Same filter as above -->
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+
         </executions>
       </plugin>
-      
+
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>
@@ -196,8 +227,8 @@
         <configuration>
           <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
         </configuration>
-      </plugin> 
-      
+      </plugin>
+
 
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -69,37 +69,110 @@
 
   <build>
     <plugins>
-      <!-- Maven Assembly Plugin -->
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.6.0</version>
-        <configuration>
-          <!-- get all project dependencies -->
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-          <!-- MainClass in mainfest make a executable jar -->
-          <archive>
-            <manifest>
-              <mainClass>
-                com.google.cloud.discotoproto3converter.DiscoToProto3ConverterApp
-              </mainClass>
-            </manifest>
-          </archive>
-
-        </configuration>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version> <!-- Use a recent version -->
         <executions>
+
+          <!-- Execution #1: DiscoToProto3ConverterApp -->
           <execution>
-            <id>make-assembly</id>
-            <!-- bind to the packaging phase -->
+            <id>shade-disco-converter</id>
             <phase>package</phase>
             <goals>
-              <goal>single</goal>
+              <goal>shade</goal>
             </goals>
+            <configuration>
+              <!-- The final name for the first binary -->
+              <finalName>disco-to-proto3-converter-app</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <!-- The main class for the first binary -->
+                  <mainClass>com.google.cloud.discotoproto3converter.DiscoToProto3ConverterApp</mainClass>
+                </transformer>
+                <!-- This transformer is good practice for merging service files -->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <!-- This helps avoid a security warning with signed JARs -->
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
           </execution>
+
+          <!-- Execution #2: ServiceConfigGeneratorApp -->
+          <execution>
+            <id>shade-service-config-generator</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <!-- The final name for the second binary -->
+              <finalName>service-config-generator-app</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <!-- The main class for the second binary -->
+                  <mainClass>com.google.cloud.discotoproto3converter.ServiceConfigGeneratorApp</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <!-- Same filter as above -->
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+
+          <!-- Execution #3: GapicYamlGeneratorApp -->
+          <execution>
+            <id>shade-gapic-yaml-generator</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <!-- The final name for the third binary -->
+              <finalName>gapic-yaml-generator-app</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <!-- The main class for the third binary -->
+                  <mainClass>com.google.cloud.discotoproto3converter.GapicYamlGeneratorApp</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+              </transformers>
+              <filters>
+                <!-- Same filter as above -->
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+          
         </executions>
       </plugin>
+      
       <plugin>
         <groupId>pl.project13.maven</groupId>
         <artifactId>git-commit-id-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
         <version>3.6.0</version> <!-- Use a recent version -->
         <executions>
 
+          <!-- TODO: Get rid of executions 1, 2, and 3, only retaining
+               4. Not doing that yet as we want this config to remain
+               relatively parallel to the Bazel BUILD rules for
+               now. -->
+
           <!-- Execution #1: DiscoToProto3ConverterApp -->
           <execution>
             <id>shade-proto3-generator</id>

--- a/src/main/java/com/google/cloud/discotoproto3converter/ConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/ConverterApp.java
@@ -185,6 +185,10 @@ public abstract class ConverterApp {
 
   public void convert(String[] args) throws IOException {
     Map<String, String> parsedArgs = parseArgs(args);
+    convert(parsedArgs);
+  }
+
+  public void convert(Map<String, String> parsedArgs) throws IOException {
     convert(
         parsedArgs.get("--discovery_doc_path"),
         parsedArgs.get("--previous_proto_file_path"),
@@ -198,7 +202,7 @@ public abstract class ConverterApp {
         parsedArgs.get("--output_comments"));
   }
 
-  protected Map<String, String> parseArgs(String[] args) {
+  protected static Map<String, String> parseArgs(String[] args) {
     Map<String, String> parsedArgs = new HashMap<>();
 
     // Optional Parameters

--- a/src/main/java/com/google/cloud/discotoproto3converter/ConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/ConverterApp.java
@@ -202,7 +202,7 @@ public abstract class ConverterApp {
         parsedArgs.get("--output_comments"));
   }
 
-  protected static Map<String, String> parseArgs(String[] args) {
+  public static Map<String, String> parseArgs(String[] args) {
     Map<String, String> parsedArgs = new HashMap<>();
 
     // Optional Parameters

--- a/src/main/java/com/google/cloud/discotoproto3converter/DiscoToProto3ConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/DiscoToProto3ConverterApp.java
@@ -25,9 +25,7 @@ public class DiscoToProto3ConverterApp extends ConverterApp {
     super(new Proto3Writer());
   }
 
-  /**
-     Returns `text` with the suffix `target` changed to `replacement`.
-   */
+  /** Returns `text` with the suffix `target` changed to `replacement`. */
   public static String replaceSuffixWith(String text, String target, String replacement) {
     int start = text.lastIndexOf(target);
     StringBuilder builder = new StringBuilder();
@@ -37,13 +35,13 @@ public class DiscoToProto3ConverterApp extends ConverterApp {
   }
 
   /**
-     Generates the proto file and, if the value of the argument "--output_file_path" ends in `.-`,
-     also the gRPC service config and the GAPIC YAML config files.
+   * Generates the proto file and, if the value of the argument "--output_file_path" ends in `.-`,
+   * also the gRPC service config and the GAPIC YAML config files.
    */
   public static void main(String[] args) throws IOException {
     String suffixForMultiFileGeneration = ".-";
     Map<String, String> parsedArgs = parseArgs(args);
-    String outputFilePathArgument="--output_file_path";
+    String outputFilePathArgument = "--output_file_path";
     String outputFileStem = parsedArgs.get(outputFilePathArgument);
 
     if (!outputFileStem.endsWith(suffixForMultiFileGeneration)) {
@@ -56,19 +54,23 @@ public class DiscoToProto3ConverterApp extends ConverterApp {
     // run all three converters
 
     System.err.print("\n\n\n*** generating protocol buffer file");
-    parsedArgs.put(outputFilePathArgument,
+    parsedArgs.put(
+        outputFilePathArgument,
         replaceSuffixWith(outputFileStem, suffixForMultiFileGeneration, ".proto"));
     DiscoToProto3ConverterApp protoConverterApp = new DiscoToProto3ConverterApp();
     protoConverterApp.convert(parsedArgs);
 
     System.err.print("\n\n\n*** generating grpc service config");
-    parsedArgs.put(outputFilePathArgument,
-        replaceSuffixWith(outputFileStem, suffixForMultiFileGeneration, "_grpc_service_config.json"));
+    parsedArgs.put(
+        outputFilePathArgument,
+        replaceSuffixWith(
+            outputFileStem, suffixForMultiFileGeneration, "_grpc_service_config.json"));
     ServiceConfigGeneratorApp serviceConfigConverterApp = new ServiceConfigGeneratorApp();
     serviceConfigConverterApp.convert(parsedArgs);
 
     System.err.print("\n\n\n*** generating gapic yaml config");
-    parsedArgs.put(outputFilePathArgument,
+    parsedArgs.put(
+        outputFilePathArgument,
         replaceSuffixWith(outputFileStem, suffixForMultiFileGeneration, "_gapic.yaml"));
     GapicYamlGeneratorApp gapicYamlGeneratorApp = new GapicYamlGeneratorApp();
     gapicYamlGeneratorApp.convert(parsedArgs);

--- a/src/main/java/com/google/cloud/discotoproto3converter/DiscoToProto3ConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/DiscoToProto3ConverterApp.java
@@ -18,61 +18,14 @@ package com.google.cloud.discotoproto3converter;
 
 import com.google.cloud.discotoproto3converter.proto3.Proto3Writer;
 import java.io.IOException;
-import java.util.Map;
 
 public class DiscoToProto3ConverterApp extends ConverterApp {
   public DiscoToProto3ConverterApp() {
     super(new Proto3Writer());
   }
 
-  /** Returns `text` with the suffix `target` changed to `replacement`. */
-  public static String replaceSuffixWith(String text, String target, String replacement) {
-    int start = text.lastIndexOf(target);
-    StringBuilder builder = new StringBuilder();
-    builder.append(text.substring(0, start));
-    builder.append(replacement);
-    return builder.toString();
-  }
-
-  /**
-   * Generates the proto file and, if the value of the argument "--output_file_path" ends in `.-`,
-   * also the gRPC service config and the GAPIC YAML config files.
-   */
   public static void main(String[] args) throws IOException {
-    String suffixForMultiFileGeneration = ".-";
-    Map<String, String> parsedArgs = parseArgs(args);
-    String outputFilePathArgument = "--output_file_path";
-    String outputFileStem = parsedArgs.get(outputFilePathArgument);
-
-    if (!outputFileStem.endsWith(suffixForMultiFileGeneration)) {
-      // only run the proto converter
-      DiscoToProto3ConverterApp converterApp = new DiscoToProto3ConverterApp();
-      converterApp.convert(parsedArgs);
-      return;
-    }
-
-    // run all three converters
-
-    System.err.print("\n\n\n*** generating protocol buffer file");
-    parsedArgs.put(
-        outputFilePathArgument,
-        replaceSuffixWith(outputFileStem, suffixForMultiFileGeneration, ".proto"));
-    DiscoToProto3ConverterApp protoConverterApp = new DiscoToProto3ConverterApp();
-    protoConverterApp.convert(parsedArgs);
-
-    System.err.print("\n\n\n*** generating grpc service config");
-    parsedArgs.put(
-        outputFilePathArgument,
-        replaceSuffixWith(
-            outputFileStem, suffixForMultiFileGeneration, "_grpc_service_config.json"));
-    ServiceConfigGeneratorApp serviceConfigConverterApp = new ServiceConfigGeneratorApp();
-    serviceConfigConverterApp.convert(parsedArgs);
-
-    System.err.print("\n\n\n*** generating gapic yaml config");
-    parsedArgs.put(
-        outputFilePathArgument,
-        replaceSuffixWith(outputFileStem, suffixForMultiFileGeneration, "_gapic.yaml"));
-    GapicYamlGeneratorApp gapicYamlGeneratorApp = new GapicYamlGeneratorApp();
-    gapicYamlGeneratorApp.convert(parsedArgs);
+    DiscoToProto3ConverterApp converterApp = new DiscoToProto3ConverterApp();
+    converterApp.convert(args);
   }
 }

--- a/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.discotoproto3converter;
+
+import com.google.cloud.discotoproto3converter.proto3.Proto3Writer;
+import java.io.IOException;
+import java.util.Map;
+
+public class DiscoveryConverterApp extends ConverterApp {
+  public DiscoveryConverterApp() {
+    super(new Proto3Writer());
+  }
+
+  public static void main(String[] args) throws IOException {
+    Map<String, String> parsedArgs = parseArgs(args);
+    String outputFilePathArgument="--output_file_path";
+    String outputFileStem = parsedArgs.get(outputFilePathArgument);
+
+    System.err.print("\n\n\n*** Generating protocol buffer file");
+    parsedArgs.put(outputFilePathArgument, outputFileStem.concat(".proto"));
+    DiscoToProto3ConverterApp protoConverterApp = new DiscoToProto3ConverterApp();
+    protoConverterApp.convert(parsedArgs);
+
+    System.err.print("\n\n\n*** Generating grpc service config");
+    parsedArgs.put(outputFilePathArgument, outputFileStem.concat("_grpc_service_config.json"));
+    ServiceConfigGeneratorApp serviceConfigConverterApp = new ServiceConfigGeneratorApp();
+    serviceConfigConverterApp.convert(parsedArgs);
+
+    System.err.print("\n\n\n*** Generating gapic yaml config");
+    parsedArgs.put(outputFilePathArgument, outputFileStem.concat("_gapic.yaml"));
+    GapicYamlGeneratorApp gapicYamlGeneratorApp = new GapicYamlGeneratorApp();
+    gapicYamlGeneratorApp.convert(parsedArgs);
+  }
+}

--- a/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
@@ -16,17 +16,13 @@
 
 package com.google.cloud.discotoproto3converter;
 
-import com.google.cloud.discotoproto3converter.proto3.Proto3Writer;
 import java.io.IOException;
 import java.util.Map;
 
-public class DiscoveryConverterApp extends ConverterApp {
-  public DiscoveryConverterApp() {
-    super(new Proto3Writer());
-  }
+public class DiscoveryConverterApp {
 
   public static void main(String[] args) throws IOException {
-    Map<String, String> parsedArgs = parseArgs(args);
+    Map<String, String> parsedArgs = ConverterApp.parseArgs(args);
     String outputFilePathArgument = "--output_file_path";
     String outputFileStem = parsedArgs.get(outputFilePathArgument);
 

--- a/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
+++ b/src/main/java/com/google/cloud/discotoproto3converter/DiscoveryConverterApp.java
@@ -27,22 +27,24 @@ public class DiscoveryConverterApp extends ConverterApp {
 
   public static void main(String[] args) throws IOException {
     Map<String, String> parsedArgs = parseArgs(args);
-    String outputFilePathArgument="--output_file_path";
+    String outputFilePathArgument = "--output_file_path";
     String outputFileStem = parsedArgs.get(outputFilePathArgument);
 
-    System.err.print("\n\n\n*** Generating protocol buffer file");
+    System.err.print("Generating protocol buffer file...");
     parsedArgs.put(outputFilePathArgument, outputFileStem.concat(".proto"));
     DiscoToProto3ConverterApp protoConverterApp = new DiscoToProto3ConverterApp();
     protoConverterApp.convert(parsedArgs);
 
-    System.err.print("\n\n\n*** Generating grpc service config");
+    System.err.print("\nGenerating grpc service config...");
     parsedArgs.put(outputFilePathArgument, outputFileStem.concat("_grpc_service_config.json"));
     ServiceConfigGeneratorApp serviceConfigConverterApp = new ServiceConfigGeneratorApp();
     serviceConfigConverterApp.convert(parsedArgs);
 
-    System.err.print("\n\n\n*** Generating gapic yaml config");
+    System.err.print("\nGenerating gapic yaml config...");
     parsedArgs.put(outputFilePathArgument, outputFileStem.concat("_gapic.yaml"));
     GapicYamlGeneratorApp gapicYamlGeneratorApp = new GapicYamlGeneratorApp();
     gapicYamlGeneratorApp.convert(parsedArgs);
+
+    System.err.print("\nDone.\n");
   }
 }


### PR DESCRIPTION
This defines a new  `discovery-converter-app` that will generate the protocol buffer definition file, the gRPC service config file, and the GAPIC YAML file at the same time. This allows all the generated files to be created with just one invocation, which simplifies some calling patterns (eg. in Docker containers).

This PR also updates the `Dockerfile` and `README.md` file to match.

This also modifies `pom.xml` to create the three distinct single-purpose binaries (as the Bazel rules do) for use cases where we want to create each of the generated files separately, in addition to the new `discovery-converter-app` binary.

